### PR TITLE
Firebaseを用いたAppleアカウント認証

### DIFF
--- a/firebase_authentication/ios/Runner/Info.plist
+++ b/firebase_authentication/ios/Runner/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
@@ -20,9 +22,22 @@
 	<string>$(FLUTTER_BUILD_NAME)</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>com.googleusercontent.apps.919729018962-5op82ubi2h9cmodpfbehns2l1ufht3dm</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleVersion</key>
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
 	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
@@ -43,24 +58,5 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
-	<key>CADisableMinimumFrameDurationOnPhone</key>
-	<true/>
-	<key>UIApplicationSupportsIndirectInputEvents</key>
-	<true/>
-	<!-- Google Sign-in Section -->
-    <key>CFBundleURLTypes</key>
-    <array>
-    	<dict>
-    		<key>CFBundleTypeRole</key>
-    		<string>Editor</string>
-    		<key>CFBundleURLSchemes</key>
-    		<array>
-    			<!-- TODO Replace this value: -->
-    			<!-- Copied from GoogleService-Info.plist key REVERSED_CLIENT_ID -->
-    			<string>com.googleusercontent.apps.919729018962-5op82ubi2h9cmodpfbehns2l1ufht3dm</string>
-    		</array>
-    	</dict>
-    </array>
-    <!-- End of the Google Sign-in Section -->
 </dict>
 </plist>

--- a/firebase_authentication/ios/Runner/Info.plist
+++ b/firebase_authentication/ios/Runner/Info.plist
@@ -29,7 +29,7 @@
 			<string>Editor</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>com.googleusercontent.apps.919729018962-5op82ubi2h9cmodpfbehns2l1ufht3dm</string>
+				<string>com.googleusercontent.apps.919729018962-gnnue45qqsgsncgcbao73gd5gr76hc75</string>
 			</array>
 		</dict>
 	</array>

--- a/firebase_authentication/ios/Runner/Runner.entitlements
+++ b/firebase_authentication/ios/Runner/Runner.entitlements
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>aps-environment</key>
+	<string>development</string>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
+</dict>
+</plist>

--- a/firebase_authentication/lib/main.dart
+++ b/firebase_authentication/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:firebase_authentication/firebase_options.dart';
 import 'package:firebase_authentication/sign_in_page.dart';
 import 'package:firebase_core/firebase_core.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 void main() async {
@@ -19,6 +20,7 @@ class MyApp extends StatelessWidget {
     return MaterialApp(
       title: 'Flutter Demo',
       theme: ThemeData(
+        platform: defaultTargetPlatform,
         primarySwatch: Colors.blue,
       ),
       home: const SignInPage(),

--- a/firebase_authentication/lib/sign_in_page.dart
+++ b/firebase_authentication/lib/sign_in_page.dart
@@ -151,9 +151,10 @@ class _SignInPageState extends State<SignInPage> {
                 Buttons.Google,
                 onPressed: signInWithGoogle,
               ),
-              SignInWithAppleButton(
-                onPressed: signInWithApple,
-              ),
+              if (Theme.of(context).platform == TargetPlatform.iOS)
+                SignInWithAppleButton(
+                  onPressed: signInWithApple,
+                ),
             ],
           ),
         ),

--- a/firebase_authentication/lib/sign_in_page.dart
+++ b/firebase_authentication/lib/sign_in_page.dart
@@ -88,10 +88,7 @@ class _SignInPageState extends State<SignInPage> {
   }
 
   Future<UserCredential> signInWithApple() async {
-    print('AppSignInを実行');
-
     final rawNonce = generateNonce();
-
     // 現在サインインしているAppleアカウントのクレデンシャルを要求する。
     final appleCredential = await SignInWithApple.getAppleIDCredential(
       scopes: [
@@ -99,13 +96,11 @@ class _SignInPageState extends State<SignInPage> {
         AppleIDAuthorizationScopes.fullName,
       ],
     );
-    print(appleCredential);
     // Apple から返されたクレデンシャルから `OAuthCredential` を作成します。
     final oauthCredential = OAuthProvider("apple.com").credential(
       idToken: appleCredential.identityToken,
       rawNonce: rawNonce,
     );
-    print(appleCredential);
     // Firebaseでユーザーにサインインします。もし、先ほど生成したnonceが
     // が `appleCredential.identityToken` の nonce と一致しない場合、サインインに失敗します。
     return await FirebaseAuth.instance.signInWithCredential(oauthCredential);

--- a/firebase_authentication/lib/sign_in_page.dart
+++ b/firebase_authentication/lib/sign_in_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_signin_button/button_list.dart';
 import 'package:flutter_signin_button/button_view.dart';
 import 'package:google_sign_in/google_sign_in.dart';
+import 'package:sign_in_with_apple/sign_in_with_apple.dart';
 
 class SignInPage extends StatefulWidget {
   const SignInPage({Key? key}) : super(key: key);
@@ -86,6 +87,30 @@ class _SignInPageState extends State<SignInPage> {
     return result;
   }
 
+  Future<UserCredential> signInWithApple() async {
+    print('AppSignInを実行');
+
+    final rawNonce = generateNonce();
+
+    // 現在サインインしているAppleアカウントのクレデンシャルを要求する。
+    final appleCredential = await SignInWithApple.getAppleIDCredential(
+      scopes: [
+        AppleIDAuthorizationScopes.email,
+        AppleIDAuthorizationScopes.fullName,
+      ],
+    );
+    print(appleCredential);
+    // Apple から返されたクレデンシャルから `OAuthCredential` を作成します。
+    final oauthCredential = OAuthProvider("apple.com").credential(
+      idToken: appleCredential.identityToken,
+      rawNonce: rawNonce,
+    );
+    print(appleCredential);
+    // Firebaseでユーザーにサインインします。もし、先ほど生成したnonceが
+    // が `appleCredential.identityToken` の nonce と一致しない場合、サインインに失敗します。
+    return await FirebaseAuth.instance.signInWithCredential(oauthCredential);
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -131,6 +156,9 @@ class _SignInPageState extends State<SignInPage> {
               SignInButton(
                 Buttons.Google,
                 onPressed: signInWithGoogle,
+              ),
+              SignInWithAppleButton(
+                onPressed: signInWithApple,
               ),
             ],
           ),

--- a/firebase_authentication/lib/sign_in_page.dart
+++ b/firebase_authentication/lib/sign_in_page.dart
@@ -147,7 +147,6 @@ class _SignInPageState extends State<SignInPage> {
                   ),
                 ],
               ),
-              // yokobayashi2001@gmail.com
               SignInButton(
                 Buttons.Google,
                 onPressed: signInWithGoogle,

--- a/firebase_authentication/pubspec.yaml
+++ b/firebase_authentication/pubspec.yaml
@@ -40,6 +40,7 @@ dependencies:
   firebase_auth: ^4.6.1
   google_sign_in: ^6.1.1
   flutter_signin_button: ^2.0.0
+  sign_in_with_apple: ^4.3.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## 概要
Firebase×FlutterでAppleアカウント認証を行う実装をしました。

## UI
<img src="https://github.com/KobayashiYoh/flutter_learning/assets/82624334/c8fa8722-60fb-40a4-b2d0-2b7a1d3346a8" width="300">

## 参考
* https://www.youtube.com/watch?v=ettlLq2gW0U&ab_channel=dbestech
* https://zenn.dev/flutteruniv_dev/articles/b92482ca1fd693
